### PR TITLE
Added error emitter for json parsing errors.

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,12 @@ module.exports = function (fileName, converter) {
     if (file.isStream()) {
       return this.emit('error', new PluginError('gulp-jsoncombine', 'Streaming not supported'));
     }
-    data[file.relative.substr(0,file.relative.length-5)] = JSON.parse(file.contents.toString());
+    try {
+      data[file.relative.substr(0,file.relative.length-5)] = JSON.parse(file.contents.toString());
+    } catch (err) {
+      return this.emit('error',
+          new PluginError('gulp-jsoncombine', 'Error parsing JSON: ' + err));
+    }
   }
 
   function endStream() {


### PR DESCRIPTION
I needed the plugin to emit an error when the parsing of json results in an error due to a syntax error in the json file. Now you can handle this error with plumber and watch keeps watching.
