### PR TITLE
Adding a check to endStream for if any files were found

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,16 +36,18 @@ module.exports = function (fileName, converter) {
   }
 
   function endStream() {
-    var joinedPath = path.join(firstFile.base, fileName);
+    if (firstFile) {
+      var joinedPath = path.join(firstFile.base, fileName);
 
-    var joinedFile = new File({
-      cwd: firstFile.cwd,
-      base: firstFile.base,
-      path: joinedPath,
-      contents: converter(data)
-    });
+      var joinedFile = new File({
+        cwd: firstFile.cwd,
+        base: firstFile.base,
+        path: joinedPath,
+        contents: converter(data)
+      });
 
-    this.emit('data', joinedFile);
+      this.emit('data', joinedFile);
+    }
     this.emit('end');
   }
 


### PR DESCRIPTION
I have a situation where I'm trying to loop through a set of matched files over a series of directories. It is the case that sometimes a file won't exist in any of them. If this is the case, currently jsoncombine fails on line 39, since firstFile is null.

This just adds a simple check to this case where the build won't blow up if we never found any files at all.
