### PR TITLE
Added error handling for the converter and fixed unit tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,8 @@ module.exports = function (fileName, converter) {
 
   var data = {};
   var firstFile = null;
+  //We keep track of when we should skip the conversion for error cases
+  var skipConversion = false;
 
   function bufferContents(file) {
     if (!firstFile) {
@@ -25,28 +27,33 @@ module.exports = function (fileName, converter) {
       return; // ignore
     }
     if (file.isStream()) {
+	  skipConversion = true;
       return this.emit('error', new PluginError('gulp-jsoncombine', 'Streaming not supported'));
     }
     try {
       data[file.relative.substr(0,file.relative.length-5)] = JSON.parse(file.contents.toString());
     } catch (err) {
+      skipConversion = true;
       return this.emit('error',
           new PluginError('gulp-jsoncombine', 'Error parsing JSON: ' + err));
     }
   }
 
   function endStream() {
-    if (firstFile) {
+    if (firstFile && !skipConversion) {
       var joinedPath = path.join(firstFile.base, fileName);
 
-      var joinedFile = new File({
-        cwd: firstFile.cwd,
-        base: firstFile.base,
-        path: joinedPath,
-        contents: converter(data)
-      });
-
-      this.emit('data', joinedFile);
+	  try {
+	    var joinedFile = new File({
+          cwd: firstFile.cwd,
+          base: firstFile.base,
+          path: joinedPath,
+          contents: converter(data)
+        });
+		this.emit('data', joinedFile);
+	  }	catch (e) {
+		return this.emit('error', new PluginError('gulp-jsoncombine', e, { showStack: true }));
+	  }
     }
     this.emit('end');
   }

--- a/test/fixtures/badHello.txt
+++ b/test/fixtures/badHello.txt
@@ -1,0 +1,1 @@
+HelloInvalidJSON

--- a/test/fixtures/hello.txt
+++ b/test/fixtures/hello.txt
@@ -1,1 +1,1 @@
-Hello
+"Hello"


### PR DESCRIPTION
This pull requests does a few things:
1. Allows consumers to throw errors in their converters.  Errors are now gracefully handled by emiting a PluginError
2. Skips data conversion process if the file is a stream or if the file could not be parsed as JSON
3. Fixes the unit tests and adds one more to test that we can throw errors in the converter.
