### PR TITLE
Specify which file contains the problem.

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = function (fileName, converter) {
     } catch (err) {
       skipConversion = true;
       return this.emit('error',
-		  new PluginError('gulp-jsoncombine', 'Error parsing JSON: ' + err + ', file: ' + file.path));
+		  new PluginError('gulp-jsoncombine', 'Error parsing JSON: ' + err + ', file: ' + file.path.slice(file.base.length)));
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = function (fileName, converter) {
     } catch (err) {
       skipConversion = true;
       return this.emit('error',
-          new PluginError('gulp-jsoncombine', 'Error parsing JSON: ' + err));
+		  new PluginError('gulp-jsoncombine', 'Error parsing JSON: ' + err + ', file: ' + file.path));
     }
   }
 

--- a/test/main.js
+++ b/test/main.js
@@ -108,7 +108,7 @@ describe("gulp-jsoncombine", function () {
 		var stream = jsoncombine("World", function (data) { });
 
 		stream.on("error", function(err) {
-			err.message.should.equal("Error parsing JSON: SyntaxError: Unexpected token H, file: badHello.txt");
+			err.message.should.equal("Error parsing JSON: SyntaxError: Unexpected token H, file: /badHello.txt");
 			done();
 		});
 

--- a/test/main.js
+++ b/test/main.js
@@ -108,7 +108,7 @@ describe("gulp-jsoncombine", function () {
 		var stream = jsoncombine("World", function (data) { });
 
 		stream.on("error", function(err) {
-			err.message.should.equal("Error parsing JSON: SyntaxError: Unexpected token H");
+			err.message.should.equal("Error parsing JSON: SyntaxError: Unexpected token H, file: badHello.txt");
 			done();
 		});
 


### PR DESCRIPTION
Hi,

We're using gulp-jscombine to combine json files as part of our build process. If one of the files contains a problem the build fails but we don't have any indication which file is the culprit. 
This pull request adds the file path to the emitted PluginError.

~ Almar
