### PR TITLE
Add the ability to alter the filenames of the merged JSON files

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,21 +2,51 @@
 var through = require('through');
 var path = require('path');
 var gutil = require('gulp-util');
+var merge = require('merge');
 var PluginError = gutil.PluginError;
 var File = gutil.File;
 
 module.exports = function (fileName, converter) {
-  if (!fileName) {
-    throw new PluginError('gulp-jsoncombine', 'Missing fileName option for gulp-jsoncombine');
+  var config;
+  var defaults = {
+    dataConverter: dataConverter,
+    pathConverter: pathConverter
+  };
+
+  function dataConverter(data) {
+    return new Buffer(JSON.stringify(data, null, '\t'));
   }
-  if (!converter) {
-    throw new PluginError('gulp-jsoncombine', 'Missing converter option for gulp-jsoncombine');
+
+  function pathConverter(file) {
+    return file.relative.substr(0,file.relative.length-5);
   }
 
   var data = {};
   var firstFile = null;
   //We keep track of when we should skip the conversion for error cases
   var skipConversion = false;
+
+  if (!fileName) {
+    throw new PluginError('gulp-jsoncombine', 'Missing fileName option for gulp-jsoncombine');
+  }
+
+  if(typeof converter === 'object') {
+    config = merge.recursive(defaults, converter);
+  } else {
+    config = defaults;
+
+    if(typeof converter === 'function') {
+      config.dataConverter = converter;
+    }
+  }
+
+  if (!config.hasOwnProperty('dataConverter') && typeof config.dataConverter !== 'function') {
+    throw new PluginError('gulp-jsoncombine', 'Missing data converter option for gulp-jsoncombine');
+  }
+
+  if (!config.hasOwnProperty('pathConverter') && typeof config.pathConverter !== 'function') {
+    throw new PluginError('gulp-jsoncombine', 'Missing path converter option for gulp-jsoncombine');
+  }
 
   function bufferContents(file) {
     if (!firstFile) {
@@ -26,16 +56,18 @@ module.exports = function (fileName, converter) {
     if (file.isNull()) {
       return; // ignore
     }
+
     if (file.isStream()) {
-	  skipConversion = true;
+      skipConversion = true;
       return this.emit('error', new PluginError('gulp-jsoncombine', 'Streaming not supported'));
     }
+
     try {
-      data[file.relative.substr(0,file.relative.length-5)] = JSON.parse(file.contents.toString());
+      data[config.pathConverter(file)] = JSON.parse(file.contents.toString());
     } catch (err) {
       skipConversion = true;
       return this.emit('error',
-		  new PluginError('gulp-jsoncombine', 'Error parsing JSON: ' + err + ', file: ' + file.path.slice(file.base.length)));
+        new PluginError('gulp-jsoncombine', 'Error parsing JSON: ' + err + ', file: ' + file.path.slice(file.base.length)));
     }
   }
 
@@ -43,18 +75,20 @@ module.exports = function (fileName, converter) {
     if (firstFile && !skipConversion) {
       var joinedPath = path.join(firstFile.base, fileName);
 
-	  try {
-	    var joinedFile = new File({
+      try {
+        var joinedFile = new File({
           cwd: firstFile.cwd,
           base: firstFile.base,
           path: joinedPath,
-          contents: converter(data)
+          contents: config.dataConverter(data)
         });
-		this.emit('data', joinedFile);
-	  }	catch (e) {
-		return this.emit('error', new PluginError('gulp-jsoncombine', e, { showStack: true }));
-	  }
+
+        this.emit('data', joinedFile);
+      } catch (e) {
+        return this.emit('error', new PluginError('gulp-jsoncombine', e, { showStack: true }));
+      }
     }
+
     this.emit('end');
   }
 

--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ module.exports = function (fileName, converter) {
     }
 
     try {
-      data[config.pathConverter(file)] = config.pathConverter(file);
+      data[config.pathConverter(file)] = config.fileConverter(file);
     } catch (err) {
       skipConversion = true;
       return this.emit('error',

--- a/index.js
+++ b/index.js
@@ -10,7 +10,8 @@ module.exports = function (fileName, converter) {
   var config;
   var defaults = {
     dataConverter: dataConverter,
-    pathConverter: pathConverter
+    pathConverter: pathConverter,
+    fileConverter: fileConverter
   };
 
   function dataConverter(data) {
@@ -19,6 +20,10 @@ module.exports = function (fileName, converter) {
 
   function pathConverter(file) {
     return file.relative.substr(0,file.relative.length-5);
+  }
+
+  function fileConverter(file) {
+    return JSON.parse(file.contents.toString());
   }
 
   var data = {};
@@ -48,6 +53,10 @@ module.exports = function (fileName, converter) {
     throw new PluginError('gulp-jsoncombine', 'Missing path converter option for gulp-jsoncombine');
   }
 
+  if (!config.hasOwnProperty('fileConverter') && typeof config.fileConverter !== 'function') {
+    throw new PluginError('gulp-jsoncombine', 'Missing file converter option for gulp-jsoncombine');
+  }
+
   function bufferContents(file) {
     if (!firstFile) {
       firstFile = file;
@@ -63,7 +72,7 @@ module.exports = function (fileName, converter) {
     }
 
     try {
-      data[config.pathConverter(file)] = JSON.parse(file.contents.toString());
+      data[config.pathConverter(file)] = config.pathConverter(file);
     } catch (err) {
       skipConversion = true;
       return this.emit('error',

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "gulp-util": "~2.2.0",
-    "merge": "^1.2.0",
+    "merge": "~1.2.0",
     "through": "*"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,3 @@
-
 {
   "name": "gulp-jsoncombine",
   "version": "1.0.3",
@@ -17,8 +16,9 @@
     "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
   },
   "dependencies": {
-    "through": "*",
-    "gulp-util": "~2.2.0"
+    "gulp-util": "~2.2.0",
+    "merge": "^1.2.0",
+    "through": "*"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
When you have JSON files contained within multiple subdirectories the array keys for the sets of data become awkward. It would be nice to have the ability to pass a function to alter the names of these keys to something more appropriate.

I've updated the second argument to accept either a function or an object. Exiting implementations will continue to work as they do. However you could now call

``` javascript
jsoncombine(filePath, {
  dataConverter: function(data){...},
  pathConverter: function(data){...}
});
```

To pass either function independently & have the plugin fall back to a default if neither are passed.
