### PR TITLE
New meta object to the content processor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
-  - '0.8'
   - '0.10'
+  - 'iojs'
+  - '4'
+  - '5'
 after_script:
   - npm run coveralls

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Usage
 
-First, install `gulp-jsoncombine` as a development dependency:
+First, install `gulp-jsoncombine` as a dependency:
 
 ```shell
 npm install --save-dev gulp-jsoncombine
@@ -13,13 +13,13 @@ npm install --save-dev gulp-jsoncombine
 
 Then, add it to your `gulpfile.js`:
 
-** This plugin will collect all the json files provided to it, parse them, put them in a dictionary where the keys of that dictionary are the filenames (sans the '.json' postfix) and pass that to a processor function. That function decides how that output should look in the resulting file. **
+** This plugin will collect all the json files provided to it, parse them, put them in a dictionary where the keys of that dictionary are the filenames (sans the '.json' suffix) and pass that to a processor function. That function decides how that output should look in the resulting file. **
 
 ```javascript
 var jsoncombine = require("gulp-jsoncombine");
 
 gulp.src("./src/*.json")
-	.pipe(jsoncombine("result.js",function(data){...}))
+	.pipe(jsoncombine("result.js",function(data, meta){...}))
 	.pipe(gulp.dest("./dist"));
 ```
 
@@ -35,10 +35,15 @@ The output filename
 #### processor
 Type: `Function`  
 
-The function that will be called with the dictionary containing all the data from the processes JSON files, where the keys of the dictionary, would be the names of the files (sans the '.json' postfix).
+The processor function will be called with two dictionaries holding the same set of keys. The keys are the filename sans the `.json` suffix of a file in the gulp stream.
 
-The function should return a new `Buffer` that would be writter to the output file.
+The first dictionary maps the filename to the string contents of the file. The second dictionary maps to a meta object containing the following keys:
 
+* `cwd` The working directory
+* `base` The base path
+* `path` The full path to the file
+
+The function should return a new `Buffer` that would be written to the output file.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -15,7 +15,8 @@ module.exports = function (fileName, converter) {
 
   var data = {};
   var firstFile = null;
-  //We keep track of when we should skip the conversion for error cases
+
+  // We keep track of when we should skip the conversion for error cases
   var skipConversion = false;
 
   function bufferContents(file) {
@@ -31,7 +32,10 @@ module.exports = function (fileName, converter) {
       return this.emit('error', new PluginError('gulp-jsoncombine', 'Streaming not supported'));
     }
     try {
-      data[file.relative.substr(0,file.relative.length-5)] = JSON.parse(file.contents.toString());
+      data[file.relative.substr(0,file.relative.length-5)] = {
+        meta: file,
+        json: JSON.parse(file.contents.toString())
+      };
     } catch (err) {
       skipConversion = true;
       return this.emit('error', new PluginError('gulp-jsoncombine', 'Error parsing JSON: ' + err + ', file: ' + file.path.slice(file.base.length)));

--- a/index.js
+++ b/index.js
@@ -27,15 +27,14 @@ module.exports = function (fileName, converter) {
       return; // ignore
     }
     if (file.isStream()) {
-	  skipConversion = true;
+      skipConversion = true;
       return this.emit('error', new PluginError('gulp-jsoncombine', 'Streaming not supported'));
     }
     try {
       data[file.relative.substr(0,file.relative.length-5)] = JSON.parse(file.contents.toString());
     } catch (err) {
       skipConversion = true;
-      return this.emit('error',
-		  new PluginError('gulp-jsoncombine', 'Error parsing JSON: ' + err + ', file: ' + file.path.slice(file.base.length)));
+      return this.emit('error', new PluginError('gulp-jsoncombine', 'Error parsing JSON: ' + err + ', file: ' + file.path.slice(file.base.length)));
     }
   }
 
@@ -43,17 +42,17 @@ module.exports = function (fileName, converter) {
     if (firstFile && !skipConversion) {
       var joinedPath = path.join(firstFile.base, fileName);
 
-	  try {
-	    var joinedFile = new File({
+      try {
+        var joinedFile = new File({
           cwd: firstFile.cwd,
           base: firstFile.base,
           path: joinedPath,
           contents: converter(data)
         });
-		this.emit('data', joinedFile);
-	  }	catch (e) {
-		return this.emit('error', new PluginError('gulp-jsoncombine', e, { showStack: true }));
-	  }
+        this.emit('data', joinedFile);
+      }	catch (e) {
+        return this.emit('error', new PluginError('gulp-jsoncombine', e, { showStack: true }));
+      }
     }
     this.emit('end');
   }

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ module.exports = function (fileName, converter) {
   }
 
   var data = {};
+  var meta = {};
   var firstFile = null;
 
   // We keep track of when we should skip the conversion for error cases
@@ -32,10 +33,9 @@ module.exports = function (fileName, converter) {
       return this.emit('error', new PluginError('gulp-jsoncombine', 'Streaming not supported'));
     }
     try {
-      data[file.relative.substr(0,file.relative.length-5)] = {
-        meta: file,
-        json: JSON.parse(file.contents.toString())
-      };
+      var name = file.relative.substr(0,file.relative.length-5);
+      data[name] = JSON.parse(file.contents.toString());
+      meta[name] = {cwd: file.cwd, base: file.base, path: file.path};
     } catch (err) {
       skipConversion = true;
       return this.emit('error', new PluginError('gulp-jsoncombine', 'Error parsing JSON: ' + err + ', file: ' + file.path.slice(file.base.length)));
@@ -51,7 +51,7 @@ module.exports = function (fileName, converter) {
           cwd: firstFile.cwd,
           base: firstFile.base,
           path: joinedPath,
-          contents: converter(data)
+          contents: converter(data, meta)
         });
         this.emit('data', joinedFile);
       }	catch (e) {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "through": "*",
-    "gulp-util": "~2.2.0"
+    "gulp-util": "^3.0.0"
   },
   "devDependencies": {
     "mocha": "*",

--- a/test/main.js
+++ b/test/main.js
@@ -31,8 +31,8 @@ describe("gulp-jsoncombine", function () {
     });
 
     var stream = jsoncombine("World", function (data) {
-      var helloTxt = data.hell;
-      return new Buffer(helloTxt + "\nWorld");
+      var helloFile = data.hell;
+      return new Buffer(helloFile.json + "\nWorld");
     });
 
     stream.on("data", function (newFile) {

--- a/test/main.js
+++ b/test/main.js
@@ -1,122 +1,123 @@
 /*global describe, it*/
 "use strict";
 
-var fs = require("fs"),
-	es = require("event-stream"),
-	should = require("should");
+var fs = require("fs");
+var es = require("event-stream");
+var should = require("should");
 
 require("mocha");
 
 delete require.cache[require.resolve("../")];
 
-var gutil = require("gulp-util"),
-	jsoncombine = require("../");
+var gutil = require("gulp-util");
+var jsoncombine = require("../");
 
 describe("gulp-jsoncombine", function () {
 
-	var expectedFile = new gutil.File({
-		path: "test/expected/hello.txt",
-		cwd: "test/",
-		base: "test/expected",
-		contents: fs.readFileSync("test/expected/hello.txt")
-	});
+  var expectedFile = new gutil.File({
+    path: "test/expected/hello.txt",
+    cwd: "test/",
+    base: "test/expected",
+    contents: fs.readFileSync("test/expected/hello.txt")
+  });
 
-	it("should produce expected file via buffer", function (done) {
+  it("should produce expected file via buffer", function (done) {
 
-		var srcFile = new gutil.File({
-			path: "test/fixtures/hello.txt",
-			cwd: "test/",
-			base: "test/fixtures",
-			contents: fs.readFileSync("test/fixtures/hello.txt")
-		});
+    var srcFile = new gutil.File({
+      path: "test/fixtures/hello.txt",
+      cwd: "test/",
+      base: "test/fixtures",
+      contents: fs.readFileSync("test/fixtures/hello.txt")
+    });
 
-		var stream = jsoncombine("World", function (data) {
-			var helloTxt = data.hell;
-			return new Buffer(helloTxt + "\nWorld");
-		});
+    var stream = jsoncombine("World", function (data) {
+      var helloTxt = data.hell;
+      return new Buffer(helloTxt + "\nWorld");
+    });
 
-		stream.on("data", function (newFile) {
+    stream.on("data", function (newFile) {
 
-			should.exist(newFile);
-			should.exist(newFile.contents);
+      should.exist(newFile);
+      should.exist(newFile.contents);
 
-			String(newFile.contents).should.equal(String(expectedFile.contents));
-			done();
-		});
+      String(newFile.contents).should.equal(String(expectedFile.contents));
+      done();
+    });
 
-		stream.write(srcFile);
-		stream.end();
-	});
+    stream.write(srcFile);
+    stream.end();
+  });
 
-	it("should error on stream", function (done) {
+  it("should error on stream", function (done) {
 
-		var srcFile = new gutil.File({
-			path: "test/fixtures/hello.txt",
-			cwd: "test/",
-			base: "test/fixtures",
-			contents: fs.createReadStream("test/fixtures/hello.txt")
-		});
+    var srcFile = new gutil.File({
+      path: "test/fixtures/hello.txt",
+      cwd: "test/",
+      base: "test/fixtures",
+      contents: fs.createReadStream("test/fixtures/hello.txt")
+    });
 
-		var stream = jsoncombine("World", function () {});
+    var stream = jsoncombine("World", function () {});
 
-		stream.on("error", function(err) {
-			err.message.should.equal("Streaming not supported");
-			done();
-		});
+    stream.on("error", function(err) {
+      err.message.should.equal("Streaming not supported");
+      done();
+    });
 
-		stream.on("data", function (newFile) {
-			should.fail(null, null, "should never get here");
-		});
+    stream.on("data", function (newFile) {
+      should.fail(null, null, "should never get here");
+    });
 
-		stream.write(srcFile);
-		stream.end();
-	});
+    stream.write(srcFile);
+    stream.end();
+  });
 
-	it("should error in converter", function (done) {
-		var srcFile = new gutil.File({
-			path: "test/fixtures/hello.txt",
-			cwd: "test/",
-			base: "test/fixtures",
-			contents: fs.readFileSync("test/fixtures/hello.txt")
-		});
+  it("should error in converter", function (done) {
+    var srcFile = new gutil.File({
+      path: "test/fixtures/hello.txt",
+      cwd: "test/",
+      base: "test/fixtures",
+      contents: fs.readFileSync("test/fixtures/hello.txt")
+    });
 
-		var stream = jsoncombine("World", function (data) {
-			throw new Error("oops");
-		});
+    var stream = jsoncombine("World", function (data) {
+      throw new Error("oops");
+    });
 
-		stream.on("error", function(err) {
-			err.message.should.equal("oops");
-			done();
-		});
+    stream.on("error", function(err) {
+      err.message.should.equal("oops");
+      done();
+    });
 
-		stream.on("data", function (newFile) {
-			should.fail(null, null, "should never get here");
-		});
+    stream.on("data", function (newFile) {
+      should.fail(null, null, "should never get here");
+    });
 
-		stream.write(srcFile);
-		stream.end();
-	});
+    stream.write(srcFile);
+    stream.end();
+  });
 
-	it("should error when parsing JSON in source file", function (done) {
-		var srcFile = new gutil.File({
-			path: "test/fixtures/badHello.txt",
-			cwd: "test/",
-			base: "test/fixtures",
-			contents: fs.readFileSync("test/fixtures/badHello.txt")
-		});
+  it("should error when parsing JSON in source file", function (done) {
+    var srcFile = new gutil.File({
+      path: "test/fixtures/badHello.txt",
+      cwd: "test/",
+      base: "test/fixtures",
+      contents: fs.readFileSync("test/fixtures/badHello.txt")
+    });
 
-		var stream = jsoncombine("World", function (data) { });
+    var stream = jsoncombine("World", function (data) { });
 
-		stream.on("error", function(err) {
-			err.message.should.equal("Error parsing JSON: SyntaxError: Unexpected token H, file: /badHello.txt");
-			done();
-		});
+    stream.on("error", function(err) {
+      err.message.should.equal("Error parsing JSON: SyntaxError: Unexpected token H, file: /badHello.txt");
+      done();
+    });
 
-		stream.on("data", function (newFile) {
-			should.fail(null, null, "should never get here");
-		});
+    stream.on("data", function (newFile) {
+      should.fail(null, null, "should never get here");
+    });
 
-		stream.write(srcFile);
-		stream.end();
-	});
+    stream.write(srcFile);
+    stream.end();
+  });
+
 });

--- a/test/main.js
+++ b/test/main.js
@@ -31,8 +31,7 @@ describe("gulp-jsoncombine", function () {
     });
 
     var stream = jsoncombine("World", function (data) {
-      var helloFile = data.hell;
-      return new Buffer(helloFile.json + "\nWorld");
+      return new Buffer(data.hell + "\nWorld");
     });
 
     stream.on("data", function (newFile) {
@@ -41,6 +40,35 @@ describe("gulp-jsoncombine", function () {
       should.exist(newFile.contents);
 
       String(newFile.contents).should.equal(String(expectedFile.contents));
+      done();
+    });
+
+    stream.write(srcFile);
+    stream.end();
+  });
+
+  it('should expose meta data via the converter', function (done) {
+
+    var srcFile = new gutil.File({
+      path: "test/fixtures/hello.txt",
+      cwd: "test/",
+      base: "test/fixtures",
+      contents: fs.readFileSync("test/fixtures/hello.txt")
+    });
+
+    var stream = jsoncombine("World", function (data, meta) {
+      var hell = meta.hell;
+      var tokens = [hell.cwd, hell.base, hell.path];
+      return new Buffer(tokens.join('\n'));
+    });
+
+    stream.on("data", function (newFile) {
+      should.exist(newFile);
+      should.exist(newFile.contents);
+      var tokens = newFile.contents.toString().split('\n');
+      tokens[0].should.eql(srcFile.cwd);
+      tokens[1].should.eql(srcFile.base);
+      tokens[2].should.eql(srcFile.path);
       done();
     });
 


### PR DESCRIPTION
This PR contains three different things:
1. Consistent indentation across the javascript files. This might make my commits seem to have changed a lot of things in the test file, while in fact only one test has been added.
2. New second argument to the content processor. I needed to access some meta data for every file processed, hence the `meta` argument. The one test added concerns this feature. This change should be backwards compatible.
3. Updates to the README
